### PR TITLE
Site icons

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -831,7 +831,7 @@
             {
                 $icon = \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png';
                 
-                if ($user_avatar_favicons)
+                if (\Idno\Core\site()->config('user_avatar_favicons'))
                 {
                     if ($user = \Idno\Core\site()->currentPage()->getOwner()) 
                     {

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -823,6 +823,27 @@
             {
                 return $this->assets[$class];
             }
+            
+            /**
+             * Get an icon for this page.
+             */
+            public function getIcon() 
+            {
+                $icon = \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png';
+                
+                if ($user_avatar_favicons)
+                {
+                    if ($user = \Idno\Core\site()->currentPage()->getOwner()) 
+                    {
+                        if ($user instanceof \Idno\Entities\User) 
+                        {
+                            $icon = $user->getIcon();
+                        }
+                    }
+                }
+                
+                return \Idno\Core\site()->triggerEvent('icon', ['object' => $this], $icon);
+            }
 
             /**
              * Set the last updated header for this page.

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -593,6 +593,36 @@
             }
 
             /**
+             * Retrieve site icons.
+             * Retrieve a set of one or more icon for the current site, allowing plugins and other components
+             * access icons for displaying in various contexts
+             * 
+             * @returns array An associative array of various icons => url
+             */
+            function getSiteIcons() 
+            {
+                $icons = [];
+                
+                // Set our defaults
+                $icons['defaults'] = [
+                    'default' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png',
+                    'default_16' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_16.png',
+                    'default_32' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_32.png',
+                    'default_64' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_64.png',
+                ];
+                
+                // If we're on a page, see if that has a specific icon
+                if ($page = \Idno\Core\site()->currentPage()) {
+                    if ($page_icons = $page->getIcon()) {
+                        $icons['page'] = $page_icons;
+                    }
+                }
+                
+                // Now, return a list of icons, but pass it through an event hook to override
+                return $this->triggerEvent('icon', ['object' => $this], $icons);                
+            }
+            
+            /**
              * Retrieve notices (eg notifications that a new version has been released) from Known HQ
              * @return mixed
              */

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -609,8 +609,14 @@
                     'default_16' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_16.png',
                     'default_32' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_32.png',
                     'default_64' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_64.png',
+                    
+                    // Apple logos
+                    'default_57' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-57x57.png',
+                    'default_72' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-72x72.png',
+                    'default_114' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-114x114.png',
+                    'default_144' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/apple-icon-144x144.png',
                 ];
-                
+                                
                 // If we're on a page, see if that has a specific icon
                 if ($page = \Idno\Core\site()->currentPage()) {
                     if ($page_icons = $page->getIcon()) {

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -619,7 +619,7 @@
                 }
                 
                 // Now, return a list of icons, but pass it through an event hook to override
-                return $this->triggerEvent('icon', ['object' => $this], $icons);                
+                return $this->triggerEvent('site/icons', ['object' => $this], $icons);                
             }
             
             /**

--- a/Idno/Core/Idno.php
+++ b/Idno/Core/Idno.php
@@ -603,7 +603,7 @@
             {
                 $icons = [];
                 
-                // Set our defaults
+                // Set our defaults (TODO: Set these cleaner, perhaps through the template system)
                 $icons['defaults'] = [
                     'default' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png',
                     'default_16' => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k_16.png',

--- a/IdnoPlugins/Firefox/templates/default/account/firefox/manifest.tpl.php
+++ b/IdnoPlugins/Firefox/templates/default/account/firefox/manifest.tpl.php
@@ -1,7 +1,12 @@
+<?php
+
+    $icons = Idno\Core\site()->getSiteIcons();
+    
+?>
     "name": "<?=htmlspecialchars(\Idno\Core\site()->config()->title)?>",
-    "iconURL": "<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/logo_k_16.png",
-    "icon32URL": "<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/logo_k_32.png",
-    "icon64URL": "<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/logo_k_64.png",
+    "iconURL": "<?=$icons['defaults']['default_16']; ?>",
+    "icon32URL": "<?=$icons['defaults']['default_32']; ?>",
+    "icon64URL": "<?=$icons['defaults']['default_64']; ?>",
 
     "workerURL": "<?=\Idno\Core\site()->config()->url?>IdnoPlugins/Firefox/worker.js",
     //"sidebarURL": "<?=\Idno\Core\site()->config()->url?>firefox/sidebar",

--- a/templates/default/shell.tpl.php
+++ b/templates/default/shell.tpl.php
@@ -29,7 +29,7 @@
             'og:type'      => 'website',
             'og:title'     => htmlspecialchars(strip_tags($vars['title'])),
             'og:site_name' => htmlspecialchars(strip_tags(\Idno\Core\site()->config()->title)),
-            'og:image'     => \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png'
+            'og:image'     => Idno\Core\site()->currentPage()->getIcon()
         );
 
         if (\Idno\Core\site()->currentPage() && \Idno\Core\site()->currentPage()->isPermalink()) {

--- a/templates/default/shell/favicon.tpl.php
+++ b/templates/default/shell/favicon.tpl.php
@@ -1,29 +1,15 @@
 <?php
 
-    $user_avatar_favicons = \Idno\Core\site()->config('user_avatar_favicons');
-    if ((\Idno\Core\site()->currentPage()) && ($user = \Idno\Core\site()->currentPage()->getOwner())) {
-        if ($user instanceof \Idno\Entities\User) {
-            $user_icon = $user->getIcon();
-            if (strpos($icon, 'thumb.jpg') !== false) {
-                $user_icon_mime = 'image/jpg';
-            } else {
-                $user_icon_mime = 'image/png';
-            }
-            if ($user_avatar_favicons) {
-                $icon      = $user_icon;
-                $icon_mime = $user_icon_mime;
-            }
-        } else {
-            $user_icon      = \Idno\Core\site()->config()->getDisplayURL() . 'gfx/logos/logo_k.png';
-            $user_icon_mime = 'image/png';
-        }
-    }
-
+    $icons = Idno\Core\site()->getSiteIcons();
+    
+    $page_icon = $icons['page'];
+    $page_icon_mime = (strpos($page_icon, '.jpg') !== false) ? 'image/jpg' : 'image/png';
+ 
 ?>
-<link rel="shortcut icon" type="<?= $icon_mime ?>" href="<?= $icon ?>">
+<link rel="shortcut icon" type="<?= $page_icon_mime ?>" href="<?= $page_icon ?>">
 <!-- Make this an "app" when saved to an ios device's home screen -->
-<link rel="apple-touch-icon-precomposed" href="<?= $user_icon ?>">
+<link rel="apple-touch-icon-precomposed" href="<?= $page_icon ?>">
 <!-- Make this an "app" when saved to an ios device's home screen -->
-<link rel="apple-touch-icon" href="<?=$user_icon?>">
+<link rel="apple-touch-icon" href="<?=$page_icon?>">
 <!-- <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black"> -->

--- a/templates/default/shell/icons.tpl.php
+++ b/templates/default/shell/icons.tpl.php
@@ -1,5 +1,8 @@
+<?php
+    $icons = Idno\Core\site()->getSiteIcons();
+?>
 <!--Le fav and touch icons-->
-<link rel="apple-touch-icon" sizes="57x57" href="<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/apple-icon-57x57.png" />
-<link rel="apple-touch-icon" sizes="72x72" href="<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/apple-icon-72x72.png" />
-<link rel="apple-touch-icon" sizes="114x114" href="<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/apple-icon-114x114.png" />
-<link rel="apple-touch-icon" sizes="144x144" href="<?=\Idno\Core\site()->config()->getDisplayURL()?>gfx/logos/apple-icon-144x144.png" />
+<link rel="apple-touch-icon" sizes="57x57" href="<?=$icons['defaults']['default_57']; ?>" />
+<link rel="apple-touch-icon" sizes="72x72" href="<?=$icons['defaults']['default_72']; ?>" />
+<link rel="apple-touch-icon" sizes="114x114" href="<?=$icons['defaults']['default_114']; ?>" />
+<link rel="apple-touch-icon" sizes="144x144" href="<?=$icons['defaults']['default_144']; ?>" />


### PR DESCRIPTION
* Introduces site()->getSiteIcons() that returns an array of icons that can be used in various contexts to render an icon suitable for display, prepopulated with defaults but overridable via event hooks.
* Introduces getIcon() on Page, which will return an icon for the current page context, overridable via icon event hook, or in code.
* Moves default icon/user icon favicon selection controller logic from favicon.tpl.php to Page::getIcon()
* Updates favicon.tpl.php, icons.tpl.php and the firefox manifest to use the new API

TODO: find a nicer way of populating defaults, perhaps via template... putting in links to graphics assets in code seems *wrong*, but couldn't think of a better way at the moment.

Closes #624 