### PR TITLE
Api gatekeepers

### DIFF
--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -546,7 +546,11 @@
             {
                 if (!\Idno\Core\site()->session()->isLoggedIn()) {
                     $this->setResponse(401);
-                    $this->forward(\Idno\Core\site()->config()->getURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']));
+                    
+                    // Forwarding loses the response code, so is only helpful if this is not an API request
+                    if (!\Idno\Core\site()->session()->isAPIRequest()) {
+                        $this->forward(\Idno\Core\site()->config()->getURL() . 'session/login?fwd=' . urlencode($_SERVER['REQUEST_URI']));
+                    }
                 }
             }
 

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -580,7 +580,9 @@
             {
                 if (\Idno\Core\site()->session()->isLoggedIn()) {
                     $this->setResponse(403);
-                    $this->forward();
+                    if (!\Idno\Core\site()->session()->isAPIRequest()) {
+                        $this->forward();
+                    }
                 }
             }
 
@@ -598,8 +600,11 @@
                     }
                 }
                 if (!$ok) {
-                    $this->setResponse(401);
-                    $this->forward();
+                    $this->setResponse(403);
+                    
+                    if (!\Idno\Core\site()->session()->isAPIRequest()) {
+                        $this->forward();
+                    }
                 }
             }
 

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -563,7 +563,10 @@
             {
                 if (!\Idno\Core\site()->canWrite()) {
                     $this->setResponse(403);
-                    $this->forward();
+                    
+                    if (!\Idno\Core\site()->session()->isAPIRequest()) {
+                        $this->forward();
+                    }
                 }
                 $this->gatekeeper();
             }

--- a/Idno/Common/Page.php
+++ b/Idno/Common/Page.php
@@ -545,7 +545,7 @@
             function gatekeeper()
             {
                 if (!\Idno\Core\site()->session()->isLoggedIn()) {
-                    $this->setResponse(401);
+                    $this->setResponse(403);
                     
                     // Forwarding loses the response code, so is only helpful if this is not an API request
                     if (!\Idno\Core\site()->session()->isAPIRequest()) {
@@ -579,7 +579,7 @@
             function reverseGatekeeper()
             {
                 if (\Idno\Core\site()->session()->isLoggedIn()) {
-                    $this->setResponse(401);
+                    $this->setResponse(403);
                     $this->forward();
                 }
             }

--- a/Idno/Core/Session.php
+++ b/Idno/Core/Session.php
@@ -407,7 +407,11 @@
                     if (!site()->session()->isLoggedOn()) {
                         $class = get_class(site()->currentPage());
                         if (!site()->isPageHandlerPublic($class)) {
-                            site()->currentPage()->forward(site()->config()->getURL() . 'session/login/');
+                            
+                            $this->setResponse(403);
+                            if (!\Idno\Core\site()->session()->isAPIRequest()) {
+                                site()->currentPage()->forward(site()->config()->getURL() . 'session/login/');
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
* Gatekeepers no longer forward if this is an api request, as this causes the response code to be lost
* Removes http 401 (which is invalid in this context), and replaces it with 403