### PR TITLE
Adds the ability to load plugins from direct checkouts

### DIFF
--- a/Idno/Core/Plugins.php
+++ b/Idno/Core/Plugins.php
@@ -21,7 +21,15 @@
              */
             public function init()
             {
-
+                // Add a classloader to look for a package autoloader
+                spl_autoload_register(function($class) {
+                    foreach (\Idno\Core\site()->config->config['plugins'] as $plugin) {
+                        if (file_exists(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $plugin . '/autoloader.php')) {
+                            include_once(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $plugin . '/autoloader.php');
+                        }
+                    }
+                });
+                
                 if (!empty(site()->config()->alwaysplugins)) {
                     site()->config->plugins = array_merge(site()->config->plugins, site()->config->alwaysplugins);
                 }
@@ -38,7 +46,7 @@
                         }
                     }
                 }
-
+                
             }
 
             /**
@@ -102,6 +110,19 @@
                         if ($folder != '.' && $folder != '..') {
                             if (file_exists(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini')) {
                                 $plugins[$folder] = parse_ini_file(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder . '/plugin.ini', true);
+                            }
+                            
+                            // See if this is a plugin as a checkout
+                            if ($subfolders = scandir(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder)) {
+                                foreach ($subfolders as $subfolder) {
+                                    if ($subfolder != '.' && $subfolder != '..') {
+                                        if (file_exists(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder . '/' . $subfolder . '/plugin.ini')) {
+                                            if (file_exists(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder . '/autoloader.php')) {
+                                                $plugins[$folder] = parse_ini_file(\Idno\Core\site()->config()->path . '/IdnoPlugins/' . $folder . '/' . $subfolder . '/plugin.ini', true);
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes #685.

Adds the ability to load plugins directly from the most common checkout, where the plugin directory is actually in a subdirectory of the repo.

It requires a file ```autoloader.php``` in the repo's root, this should contain the following code:

```php
/**
 * Support loading of direct checkout.
 */
spl_autoload_register(function($class) {
        $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);

	$segments = explode(DIRECTORY_SEPARATOR, $class);
	$PLUGIN_NAME = $segments[1];

        $basedir = dirname(dirname(dirname(__FILE__))) . '/'; 
        $file = str_replace($PLUGIN_NAME, basename(dirname(__FILE__)) . "/$PLUGIN_NAME", $class);

	\Idno\Core\site()->plugins()->plugins[basename(dirname(__FILE__))] = \Idno\Core\site()->plugins()->plugins[$PLUGIN_NAME];
	unset(\Idno\Core\site()->plugins()->plugins[$PLUGIN_NAME]);

        if (file_exists($basedir . $file . '.php')) {
                include_once($basedir . $file . '.php');
        }

});
```