### PR TITLE
Reverting accidental inclusion of visible non-ssl warnings.

### DIFF
--- a/Idno/Pages/Account/Register.php
+++ b/Idno/Pages/Account/Register.php
@@ -49,9 +49,9 @@
                 $code       = $this->getInput('code');
                 $onboarding = $this->getInput('onboarding');
 
-                if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
+                /*if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
                     \Idno\Core\site()->session()->addErrorMessage("Warning: Access credentials were sent over a non-secured connection! To disable this warning set disable_cleartext_warning in your config.ini");
-                }
+                }*/
                 
                 if (empty(\Idno\Core\site()->config()->open_registration)) {
                     if (!($invitation = \Idno\Entities\Invitation::validate($email, $code))) {

--- a/Idno/Pages/Account/Settings.php
+++ b/Idno/Pages/Account/Settings.php
@@ -30,9 +30,9 @@
                 $password = trim($this->getInput('password'));
                 $username = trim($this->getInput('handle'));
                 
-                if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
+                /*if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
                     \Idno\Core\site()->session()->addErrorMessage("Warning: Access credentials were sent over a non-secured connection! To disable this warning set disable_cleartext_warning in your config.ini");
-                }
+                }*/
 
                 if (!empty($name)) {
                     $user->setTitle($name);

--- a/Idno/Pages/Session/Login.php
+++ b/Idno/Pages/Session/Login.php
@@ -32,9 +32,9 @@
 
             function postContent()
             {
-                if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
+                /*if (!\Idno\Common\Page::isSSL() && !\Idno\Core\site()->config()->disable_cleartext_warning) {
                     \Idno\Core\site()->session()->addErrorMessage("Warning: Access credentials were sent over a non-secured connection! To disable this warning set disable_cleartext_warning in your config.ini");
-                }
+                }*/
                     
                 $fwd = $this->getInput('fwd'); // Forward to a new page?
                 if (empty($fwd)) {


### PR DESCRIPTION
I accidentally included some visible warnings on my ssl warning patch, which shouldn't have been there (given my assertion that it was API only). Very sorry about that, reverted by this patch. 
